### PR TITLE
Disemvowel + Area_Kick fix

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -22,6 +22,7 @@ from enum import Enum
 from server.constants import TargetType
 
 import time
+import re
 
 
 
@@ -136,10 +137,9 @@ class ClientManager:
 
         def change_area(self, area):
             if self.area == area:
-                raise ClientError('You are already in this area.')
+                raise ClientError('User already in specified area.')
             if area.is_locked and not self.is_mod and not self.ipid in self.area.invite_list:
-                self.send_host_message("That area is locked!")
-                return
+                raise ClientError("That area is locked!")
             old_area = self.area
             if not area.is_char_available(self.char_id):
                 try:

--- a/server/commands.py
+++ b/server/commands.py
@@ -533,7 +533,7 @@ def ooc_cmd_area_kick(client, arg):
     if not client.area.is_locked and not client.is_mod:
         raise ClientError('Area isn\'t locked.')
     if not arg:
-        raise ClientError('You must specify a target. Use /area_kick <id>')
+        raise ClientError('You must specify a target. Use /area_kick <id> [destination #]')
     arg = arg.split(' ')
     targets = client.server.client_manager.get_targets(client, TargetType.ID, int(arg[0]), False)
     if targets:


### PR DESCRIPTION
Disemvowel did not have "re" imported, and thus would not run.

area_kick has been fixed to actually function (It was not using c.change_area correctly) and altered to have a default and specified value

Usage: /area_kick ID AREA
area defaults to 0 if not specified.

Small change to wording of change_area so that it works regardless of context, and stops processing if the area in question is locked.