### PR TITLE
/forcepos and fixed area lock shenanigans

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,16 @@ Requires Python 3.6+ and PyYAML.
     - Makes you a CM of this area.
 ### CM Commands
 * **area_lock**
-    - Locks your area.
+    - Locks your area, preventing anyone outside of the invite list from speaking IC.
 * **area_unlock**
     - Unlocks your area.
 * **invite** "ID"
     - Adds target in invite list of your area.
-* **area_kick** "ID"
-    - Kicks target and all his(same for all genders) multi-accs from your area and remove him from invite-list.
+* **uninvite** "ID"
+    - Removes target from invite list of your area.
+* **forcepos** "position" [target]
+    - Forcibly change [target]'s position. Leave blank to affect everyone in area.
+    - Positions: 'def', 'pro', 'hld', 'hlp', 'jud', 'wit'
 ### Mod Commands
 * **login** "Password"
 * **gm** "Message" 
@@ -105,6 +108,8 @@ Requires Python 3.6+ and PyYAML.
     - Kicks a player back to the character select screen. If no ID was entered then target yourself.
 * **kick** "IPID" 
     - Kicks the targets with this IPID.
+* **area_kick** "ID" [area]
+    - Kicks target and all of their multi-accs from your area to area 0 or specified [area] and removes them from invite-list should the area be locked.
 * **ban** "IPID" 
     - Bans the IPID (hdid is linked to ipid so all bans happens in a same time).
 * **unban** "IPID" 

--- a/server/aoprotocol.py
+++ b/server/aoprotocol.py
@@ -332,7 +332,7 @@ class AOProtocol(asyncio.Protocol):
         if self.client.is_muted:  # Checks to see if the client has been muted by a mod
             self.client.send_host_message("You have been muted by a moderator")
             return
-        if not self.client.area.can_send_message():
+        if not self.client.area.can_send_message(self.client):
             return
         if not self.validate_net_cmd(args, self.ArgType.STR, self.ArgType.STR_OR_EMPTY, self.ArgType.STR,
                                      self.ArgType.STR,

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -117,9 +117,10 @@ class AreaManager:
 
 
         def can_send_message(self, client):
-            client.send_host_message(
-                'whoa you spoke. ipid: {}, invite_list: {}'.format(client.ipid, client.area.invite_list))
-            return (self.is_locked and not client.is_mod and not client.ipid in self.invite_list) or (time.time() * 1000.0 - self.next_message_time) > 0
+            if self.is_locked and not client.is_mod and not client.ipid in self.invite_list:
+                client.send_host_message('This is a locked area - ask the CM to speak.')
+                return False
+            return (time.time() * 1000.0 - self.next_message_time) > 0
 
         def change_hp(self, side, val):
             if not 0 <= val <= 10:

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -116,8 +116,10 @@ class AreaManager:
                                                                         lambda: self.play_music(name, -1, length))
 
 
-        def can_send_message(self):
-            return (time.time() * 1000.0 - self.next_message_time) > 0
+        def can_send_message(self, client):
+            client.send_host_message(
+                'whoa you spoke. ipid: {}, invite_list: {}'.format(client.ipid, client.area.invite_list))
+            return (self.is_locked and not client.is_mod and not client.ipid in self.invite_list) or (time.time() * 1000.0 - self.next_message_time) > 0
 
         def change_hp(self, side, val):
             if not 0 <= val <= 10:

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -149,9 +149,9 @@ class ClientManager:
         def change_area(self, area):
             if self.area == area:
                 raise ClientError('User already in specified area.')
-            if area.is_locked and not self.is_mod and not self.ipid in self.area.invite_list:
+            if area.is_locked and not self.is_mod and not self.ipid in area.invite_list:
                 self.send_host_message('This area is locked - you will be unable to send messages ICly.')
-                # raise ClientError("That area is locked!")
+                #raise ClientError("That area is locked!")
             old_area = self.area
             if not area.is_char_available(self.char_id):
                 try:

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -150,7 +150,8 @@ class ClientManager:
             if self.area == area:
                 raise ClientError('User already in specified area.')
             if area.is_locked and not self.is_mod and not self.ipid in self.area.invite_list:
-                raise ClientError("That area is locked!")
+                self.send_host_message('This area is locked - you will be unable to send messages ICly.')
+                # raise ClientError("That area is locked!")
             old_area = self.area
             if not area.is_char_available(self.char_id):
                 try:

--- a/server/commands.py
+++ b/server/commands.py
@@ -592,7 +592,7 @@ def ooc_cmd_uninvite(client, arg):
     if targets:
         try:
             for c in targets:
-                client.send_host_message("You remove {} from the whitelist.".format(c.get_char_name()))
+                client.send_host_message("You have removed {} from the whitelist.".format(c.get_char_name()))
                 c.send_host_message("You were removed from the area whitelist.")
                 if client.area.is_locked:
                     client.area.invite_list.pop(c.ipid)


### PR DESCRIPTION
Adds /forcepos [pos] [target]
you can omit [target] to force everyone in area into pos [pos]
This is a CM or mod-only command
Fixed area locking and made it so you can peanut in areas but unable to speak ICly unless invited.
Added /uninvite and made /area_kick command mod-only.