### PR TITLE
/refresh now disconnects clients

### DIFF
--- a/server/commands.py
+++ b/server/commands.py
@@ -830,6 +830,7 @@ def ooc_cmd_refresh(client, arg):
         try:
             client.server.refresh()
             client.send_host_message('You have reloaded the server.')
+            client.server.force_restart(pred=lambda c: not c.is_mod)
         except ServerError:
             raise
 

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -233,6 +233,11 @@ class TsuServer3:
         for client in self.client_manager.clients:
             if pred(client):
                 client.send_command(cmd, *args)
+				
+    def force_restart(self, pred=lambda x: True):
+        for client in self.client_manager.clients:
+            if pred(client):
+                client.disconnect()
 
     def broadcast_global(self, client, msg, as_mod=False):
         char_name = client.get_char_name()


### PR DESCRIPTION
Now when you do /refresh everyone but the mods will get kicked out of the server. Prevents some weird shenanigans when it comes to playing a character when it is suddenly removed from the character list, etc., and a workaround for getting the new character list to update, basically.