### PR TITLE
2.6.0 fixes

### DIFF
--- a/server/commands.py
+++ b/server/commands.py
@@ -842,7 +842,7 @@ def ooc_cmd_uncm(client, arg):
     else:
         raise ClientError('You must be authorized to do that.')
 
-
+# LEGACY
 def ooc_cmd_setcase(client, arg):
     args = re.findall(r'(?:[^\s,"]|"(?:\\.|[^"])*")+', arg)
     if len(args) == 0:
@@ -856,7 +856,7 @@ def ooc_cmd_setcase(client, arg):
         client.casing_jur = args[5] == "1"
         client.casing_steno = args[6] == "1"
 
-
+# LEGACY
 def ooc_cmd_anncase(client, arg):
     if client in client.area.owners:
         if not client.can_call_case():
@@ -897,7 +897,6 @@ def ooc_cmd_anncase(client, arg):
                 client)
     else:
         raise ClientError('You cannot announce a case in an area where you are not a CM!')
-
 
 def ooc_cmd_unmod(client, arg):
     client.is_mod = False

--- a/server/commands.py
+++ b/server/commands.py
@@ -804,7 +804,9 @@ def ooc_cmd_cm(client, arg):
             try:
                 id = int(id)
                 c = client.server.client_manager.get_targets(client, TargetType.ID, id, False)[0]
-                if c in client.area.owners:
+                if not c in client.area.clients:
+                    raise ArgumentError('You can only \'nominate\' people to be CMs when they are in the area.')
+                elif c in client.area.owners:
                     client.send_host_message('{} [{}] is already a CM here.'.format(c.get_char_name(), c.id))
                 else:
                     client.area.owners.append(c)
@@ -819,7 +821,7 @@ def ooc_cmd_cm(client, arg):
 
 
 def ooc_cmd_uncm(client, arg):
-    if client in client.area.owners:
+    if client in client.area.owners or client.is_mod:
         if len(arg) > 0:
             arg = arg.split(' ')
         else:

--- a/server/evidence.py
+++ b/server/evidence.py
@@ -56,7 +56,7 @@ class EvidenceList:
         if client.area.evidence_mod == 'FFA':
             pass
         if client.area.evidence_mod == 'Mods':
-            if not client in client.area.owners:
+            if not client.is_mod:
                 return False
         if client.area.evidence_mod == 'CM':
             if not client in client.area.owners and not client.is_mod:

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -261,8 +261,8 @@ class TsuServer3:
         area_name = client.area.name
         area_id = client.area.abbreviation
         self.send_all_cmd_pred('CT', '{}'.format(self.config['hostname']),
-                               ['=== Advert ===\r\n{} in {} [{}] needs {}\r\n==============='
-                               .format(char_name, area_name, area_id, msg), '1'], pred=lambda x: not x.muted_adverts)
+                               '=== Advert ===\r\n{} in {} [{}] needs {}\r\n==============='
+                               .format(char_name, area_name, area_id, msg), '1', pred=lambda x: not x.muted_adverts)
         if self.config['use_district']:
             self.district_client.send_raw_message('NEED#{}#{}#{}#{}'.format(char_name, area_name, area_id, msg))
 


### PR DESCRIPTION
This fixes some of the CC-original bugs and strange things in the code, namely:
- CMs can now only promote people in the same area as themselves. Previously, people could be promoted to CMs from other areas, too, and this resulted in basically one-person targeted spam, as CMs can see what happens in their areas.
- Mods can now un-CM people even if they're not CMs. This is to stop people hogging areas.
- Evidence mod "Mods" now actually only allows mods to add evidence, for the first time.
- Case announcement and casing preferences now have their own netcodes, instead of being commands only. The commands still exist for legacy purposes.

An AO client PR will soon follow suit that modifies case announcement and case preferences setting on the client side to use netcodes as well.