### PR TITLE
Ban fix

### DIFF
--- a/server/ban_manager.py
+++ b/server/ban_manager.py
@@ -22,15 +22,26 @@ from server.exceptions import ServerError
 
 class BanManager:
     def __init__(self):
-        self.bans = []
+        self.bans = [] #each element: [ipid, reason]
         self.load_banlist()
 
     def load_banlist(self):
         try:
             with open('storage/banlist.json', 'r') as banlist_file:
                 self.bans = json.load(banlist_file)
+                try: #if this fails, or throws a TypeError, we should convert banlist to 2.6.0 style
+                    if len(self.bans[0]) != 2:
+                        self.convert_to_modern_banlist()
+                except TypeError:
+                    self.convert_to_modern_banlist()
+                    
         except FileNotFoundError:
             return
+
+    def convert_to_modern_banlist():
+        bantmp = self.bans
+        for ipid in bantmp:
+            self.write_banlist(ipid, 'N/A')
 
     def write_banlist(self):
         with open('storage/banlist.json', 'w') as banlist_file:

--- a/server/ban_manager.py
+++ b/server/ban_manager.py
@@ -36,17 +36,17 @@ class BanManager:
         with open('storage/banlist.json', 'w') as banlist_file:
             json.dump(self.bans, banlist_file)
 
-    def add_ban(self, ip, reason):
-        if not self.is_banned(ip):
-            self.bans.append([ip, reason])
+    def add_ban(self, ipid, reason):
+        if not self.is_banned(ipid):
+            self.bans.append([ipid, reason])
         else:
             raise ServerError('This IPID is already banned.')
         self.write_banlist()
 
-    def remove_ban(self, ip):
-        if self.is_banned(ip):
+    def remove_ban(self, ipid):
+        if self.is_banned(ipid):
             for ban in bans:
-                if ip in ban:
+                if ipid in ban:
                     self.bans.remove(ban)
         
         else:
@@ -55,12 +55,12 @@ class BanManager:
 
     def is_banned(self, ipid):
         for ban in self.bans:
-            if ip in ban:
+            if ipid in ban:
                 return True
         return False
 
     def get_ban_reason(self, ipid):
         for ban in self.bans:
-            if ip in ban:
+            if ipid in ban:
                 return ban[1]
         raise ServerError('This IPID is not banned.')

--- a/server/ban_manager.py
+++ b/server/ban_manager.py
@@ -22,57 +22,51 @@ from server.exceptions import ServerError
 
 class BanManager:
     def __init__(self):
-        self.bans = [] #each element: [ipid, reason]
+        self.bans = {} # "ipid": {"Reason": "reason"}
         self.load_banlist()
 
     def load_banlist(self):
         try:
             with open('storage/banlist.json', 'r') as banlist_file:
                 self.bans = json.load(banlist_file)
-                try: #if this fails, or throws a TypeError, we should convert banlist to 2.6.0 style
-                    if len(self.bans[0]) != 2:
-                        self.convert_to_modern_banlist()
-                except TypeError:
+                if type(self.bans) is not dict:
                     self.convert_to_modern_banlist()
-                    
         except FileNotFoundError:
             return
 
     def convert_to_modern_banlist(self):
         bantmp = self.bans
-        self.bans = []
+        self.bans = {}
         for ipid in bantmp:
-            self.add_ban(ipid, 'N/A')
+            self.add_ban(str(ipid), 'N/A')
 
     def write_banlist(self):
         with open('storage/banlist.json', 'w') as banlist_file:
             json.dump(self.bans, banlist_file)
 
     def add_ban(self, ipid, reason):
+        ipid = str(ipid)
         if not self.is_banned(ipid):
-            self.bans.append([ipid, reason])
+            self.bans[ipid] = {'Reason': reason}
         else:
             raise ServerError('This IPID is already banned.')
         self.write_banlist()
 
     def remove_ban(self, ipid):
+        ipid = str(ipid)
         if self.is_banned(ipid):
-            for ban in bans:
-                if ipid in ban:
-                    self.bans.remove(ban)
-        
+            del self.bans[ipid]
         else:
             raise ServerError('This IPID is not banned.')
         self.write_banlist()
 
     def is_banned(self, ipid):
-        for ban in self.bans:
-            if ipid in ban:
-                return True
-        return False
+        ipid = str(ipid)
+        return ipid in self.bans
 
     def get_ban_reason(self, ipid):
-        for ban in self.bans:
-            if ipid in ban:
-                return ban[1]
-        raise ServerError('This IPID is not banned.')
+        ipid = str(ipid)
+        if self.is_banned(ipid):
+            return self.bans[ipid]["Reason"]
+        else:
+            raise ServerError('This IPID is not banned.')

--- a/server/ban_manager.py
+++ b/server/ban_manager.py
@@ -36,19 +36,31 @@ class BanManager:
         with open('storage/banlist.json', 'w') as banlist_file:
             json.dump(self.bans, banlist_file)
 
-    def add_ban(self, ip):
-        if ip not in self.bans:
-            self.bans.append(ip)
+    def add_ban(self, ip, reason):
+        if not self.is_banned(ip):
+            self.bans.append([ip, reason])
         else:
             raise ServerError('This IPID is already banned.')
         self.write_banlist()
 
     def remove_ban(self, ip):
-        if ip in self.bans:
-            self.bans.remove(ip)
+        if self.is_banned(ip):
+            for ban in bans:
+                if ip in ban:
+                    self.bans.remove(ban)
+        
         else:
             raise ServerError('This IPID is not banned.')
         self.write_banlist()
 
     def is_banned(self, ipid):
-        return (ipid in self.bans)
+        for ban in self.bans:
+            if ip in ban:
+                return True
+        return False
+
+    def get_ban_reason(self, ipid):
+        for ban in self.bans:
+            if ip in ban:
+                return ban[1]
+        raise ServerError('This IPID is not banned.')

--- a/server/ban_manager.py
+++ b/server/ban_manager.py
@@ -38,10 +38,11 @@ class BanManager:
         except FileNotFoundError:
             return
 
-    def convert_to_modern_banlist():
+    def convert_to_modern_banlist(self):
         bantmp = self.bans
+        self.bans = []
         for ipid in bantmp:
-            self.write_banlist(ipid, 'N/A')
+            self.add_ban(ipid, 'N/A')
 
     def write_banlist(self):
         with open('storage/banlist.json', 'w') as banlist_file:

--- a/server/commands.py
+++ b/server/commands.py
@@ -423,21 +423,23 @@ def ooc_cmd_ban(client, arg):
     if len(arg) == 0:
         raise ArgumentError('You must specify a target. Use /ban <ipid> [reason]')
     args = list(arg.split(' '))
+
     raw_ipid = args[0]
+    reason = ' '.join(args[1:])
+    if reason == '':
+        reason = 'N/A'
+
     try:
         ipid = int(raw_ipid)
     except:
         raise ClientError('{} does not look like a valid IPID.'.format(raw_ipid))
     try:
-        client.server.ban_manager.add_ban(ipid)
+        client.server.ban_manager.add_ban(ipid, reason)
     except ServerError:
         raise
     if ipid != None:
         targets = client.server.client_manager.get_targets(client, TargetType.IPID, ipid, False)
         if targets:
-            reason = ' '.join(args[1:])
-            if reason == '':
-                reason = 'N/A'
             for c in targets:
                 c.send_command('KB', reason)
                 c.disconnect()

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -158,7 +158,7 @@ class AOProtocol(asyncio.Protocol):
             self.client.server.dump_hdids()
         for ipid in self.client.server.hdid_list[self.client.hdid]:
             if self.server.ban_manager.is_banned(ipid):
-                self.client.send_command('BD')
+                self.client.send_command('BD', self.server.ban_manager.get_ban_reason(ipid))
                 self.client.disconnect()
                 return
         logger.log_server('Connected. HDID: {}.'.format(self.client.hdid), self.client)

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -55,7 +55,7 @@ class AOProtocol(asyncio.Protocol):
         buf = data
 
         if not self.client.is_checked and self.server.ban_manager.is_banned(self.client.ipid):
-            self.client.send_command('BD', self.server.ban_manager.get_ban_reason(ipid))
+            self.client.send_command('BD', self.server.ban_manager.get_ban_reason(self.client.ipid))
             self.client.transport.close()
         else:
             self.client.is_checked = True

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -55,7 +55,7 @@ class AOProtocol(asyncio.Protocol):
         buf = data
 
         if not self.client.is_checked and self.server.ban_manager.is_banned(self.client.ipid):
-            self.client.send_command('BD')
+            self.client.send_command('BD', self.server.ban_manager.get_ban_reason(ipid))
             self.client.transport.close()
         else:
             self.client.is_checked = True

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -55,6 +55,7 @@ class AOProtocol(asyncio.Protocol):
         buf = data
 
         if not self.client.is_checked and self.server.ban_manager.is_banned(self.client.ipid):
+            self.client.send_command('BD')
             self.client.transport.close()
         else:
             self.client.is_checked = True


### PR DESCRIPTION
The ban reason is now stored with the banned ipid in `banlist.json` where the form for each ban entry is `[ipid, reason]`. This does mean that old banlists need to be updated to this format. I added a (probably kinda jank) check on `load_banlist` to see if we need to update the format, and a method to upgrade old banlists to the new format (all reasons are set to "N/A" when upgrading). 
The ban reason is now sent to clients in the BD packet. But a change needs to happen in the client so the client will show the ban reason.

There was also a ban check in `net_cmd_hi` that I don't believe can get hit. I wasn't quite sure so I decided to update that to send the reason as well.