### PR TITLE
Use send_ooc instead of ClientError in net_cmd_casea

### DIFF
--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -770,9 +770,10 @@ class AOProtocol(asyncio.Protocol):
 
             if not args[1] == "1" and not args[2] == "1" and not args[
                     3] == "1" and not args[4] == "1" and not args[5] == "1":
-                raise ArgumentError(
+                self.client.send_ooc(
                     'You should probably announce the case to at least one person.'
                 )
+                return
             msg = '=== Case Announcement ===\r\n{} [{}] is hosting {}, looking for '.format(
                 self.client.char_name, self.client.id, args[0])
 

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -764,8 +764,9 @@ class AOProtocol(asyncio.Protocol):
             return
         if self.client in self.client.area.owners:
             if not self.client.can_call_case():
-                raise ClientError(
+                self.client.send_ooc(
                     'Please wait 60 seconds between case announcements!')
+                return
 
             if not args[1] == "1" and not args[2] == "1" and not args[
                     3] == "1" and not args[4] == "1" and not args[5] == "1":
@@ -791,7 +792,7 @@ class AOProtocol(asyncio.Protocol):
                 zip(('message', 'def', 'pro', 'jud', 'jur', 'steno'), args)}
             database.log_room('case', self.client, self.client.area, message=log_data)
         else:
-            raise ClientError(
+            self.client.send_ooc(
                 'You cannot announce a case in an area where you are not a CM!'
             )
 


### PR DESCRIPTION
Use send_ooc instead of ClientError in net_cmd_casea to avoid disconnecting the client.
Fix for https://github.com/AttorneyOnline/tsuserver3/issues/61