### PR TITLE
Multi con cap and afk

### DIFF
--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -71,4 +71,4 @@ wtce_floodguard:
 zalgo_tolerance: 3
 
 #How many simultanious connections a user can do to the server. If this option is removed the default value is 3
-Multiclient_limit: 4
+multiclient_limit: 16

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -69,3 +69,6 @@ wtce_floodguard:
 
 # How many subscripts zalgo is stripped by; 3 is recommended as not to hurt special language diacritics
 zalgo_tolerance: 3
+
+#How many simultanious connections a user can do to the server. If this option is removed the default value is 3
+Multiclient_limit: 4

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -70,5 +70,5 @@ wtce_floodguard:
 # How many subscripts zalgo is stripped by; 3 is recommended as not to hurt special language diacritics
 zalgo_tolerance: 3
 
-# How many simultanious connections a user can do to the server. If this option is removed the default value is 3
+# How many simultaneous connections an IP address can make to the server. (Default: 16)
 multiclient_limit: 16

--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -70,5 +70,5 @@ wtce_floodguard:
 # How many subscripts zalgo is stripped by; 3 is recommended as not to hurt special language diacritics
 zalgo_tolerance: 3
 
-#How many simultanious connections a user can do to the server. If this option is removed the default value is 3
+# How many simultanious connections a user can do to the server. If this option is removed the default value is 3
 multiclient_limit: 16

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -87,7 +87,7 @@ class AreaManager:
             self.jukebox_prev_char_id = -1
 
             self.owners = []
-
+            self.afkers = []
         class Locked(Enum):
             """Lock state of an area."""
             FREE = 1,

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -268,7 +268,7 @@ class ClientManager:
                     'This area is spectatable, but not free - you cannot talk in-character unless invited.'
                 )
 
-			if self in self.area.afkers:
+            if self in self.area.afkers:
                 self.server.client_manager.toggle_afk(self)
             if self.area.jukebox:
                 self.area.remove_jukebox_vote(self, True)
@@ -602,7 +602,7 @@ class ClientManager:
                 elif key == TargetType.IPID:
                     if client.ipid == value:
                         targets.append(client)
-				elif key == TargetType.AFK:
+                elif key == TargetType.AFK:
                      if client in area.afkers:
                         targets.append(client)
         return targets

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -268,6 +268,8 @@ class ClientManager:
                     'This area is spectatable, but not free - you cannot talk in-character unless invited.'
                 )
 
+			if self in self.area.afkers:
+                self.server.client_manager.toggle_afk(self)
             if self.area.jukebox:
                 self.area.remove_jukebox_vote(self, True)
 
@@ -581,8 +583,6 @@ class ClientManager:
         if key == TargetType.ALL:
             for nkey in range(6):
                 targets += self.get_targets(client, nkey, value, local)
-        elif key == TargetType.AFK:
-            return list(area.afkers)
         for area in areas:
             for client in area.clients:
                 if key == TargetType.IP:
@@ -601,6 +601,9 @@ class ClientManager:
                         targets.append(client)
                 elif key == TargetType.IPID:
                     if client.ipid == value:
+                        targets.append(client)
+				elif key == TargetType.AFK:
+                     if client in area.afkers:
                         targets.append(client)
         return targets
 

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -513,11 +513,9 @@ class ClientManager:
         self.cur_id = [i for i in range(self.server.config['playerlimit'])]
 
 
-    def new_client_auth(self,transport): #future authentication methods should go here
-        try:
-            maxclients = self.server.config['Multiclient_limit']
-        except:
-            maxclients = 3
+    def new_client_preauth(self,transport): #future pre authentication methods for security concerns should go here
+
+        maxclients = self.server.config['multiclient_limit']
         temp_ipid = database.ipid(transport.get_extra_info('peername')[0])
         for client in self.server.client_manager.clients:
             if client.ipid == temp_ipid:
@@ -537,7 +535,7 @@ class ClientManager:
         temp_ipid = c.ipid
         for client in self.server.client_manager.clients:
             if c.ipid == temp_ipid:
-                c.clientscon = c.clientscon + 1
+                c.clientscon += 1
         return c
 
     def remove_client(self, client):
@@ -558,9 +556,10 @@ class ClientManager:
         temp_ipid = client.ipid
         for client in self.server.client_manager.clients:
             if client.ipid == temp_ipid:
-                client.clientscon = client.clientscon - 1
+                client.clientscon -= 1
         self.clients.remove(client)
-
+        if client in client.area.afkers:
+            client.area.afkers.remove(client)
     def get_targets(self, client, key, value, local=False, single=False):
         """
         Find players by a combination of identifying data.
@@ -582,6 +581,8 @@ class ClientManager:
         if key == TargetType.ALL:
             for nkey in range(6):
                 targets += self.get_targets(client, nkey, value, local)
+        elif key == TargetType.AFK:
+            return list(area.afkers)
         for area in areas:
             for client in area.clients:
                 if key == TargetType.IP:
@@ -600,9 +601,6 @@ class ClientManager:
                         targets.append(client)
                 elif key == TargetType.IPID:
                     if client.ipid == value:
-                        targets.append(client)
-                elif key == TargetType.AFK:
-                     if client in area.afkers:
                         targets.append(client)
         return targets
 

--- a/server/commands/area.py
+++ b/server/commands/area.py
@@ -268,8 +268,14 @@ def ooc_cmd_area_kick(client, arg):
         raise ClientError(
             'You must specify a target. Use /area_kick <id> [destination #]')
     arg = arg.split(' ')
-    targets = client.server.client_manager.get_targets(client, TargetType.ID,
-                                                       int(arg[0]), False)
+    if arg[0] == 'afk':
+        trgtype = TargetType.AFK
+        argi = arg[0]
+    else:
+        trgtype = TargetType.ID
+        argi = int(arg[0])
+    targets = client.server.client_manager.get_targets(client, trgtype,
+                                                       argi, False)
     if targets:
         try:
             for c in targets:

--- a/server/commands/casing.py
+++ b/server/commands/casing.py
@@ -140,7 +140,7 @@ def ooc_cmd_cm(client, arg):
         raise ClientError('You must be authorized to do that.')
 
 
-
+@mod_only(area_owners=True)
 def ooc_cmd_uncm(client, arg):
     """
     Remove a case manager from the current area.

--- a/server/commands/casing.py
+++ b/server/commands/casing.py
@@ -17,7 +17,8 @@ __all__ = [
     'ooc_cmd_anncase',
     'ooc_cmd_blockwtce',
     'ooc_cmd_unblockwtce',
-    'ooc_cmd_judgelog'
+    'ooc_cmd_judgelog',
+    'ooc_cmd_afk'
 ]
 
 
@@ -139,7 +140,7 @@ def ooc_cmd_cm(client, arg):
         raise ClientError('You must be authorized to do that.')
 
 
-@mod_only(area_owners=True)
+
 def ooc_cmd_uncm(client, arg):
     """
     Remove a case manager from the current area.
@@ -304,3 +305,5 @@ def ooc_cmd_judgelog(client, arg):
         raise ServerError(
             'There have been no judge actions in this area since start of session.'
         )
+def ooc_cmd_afk(client, arg):
+    client.server.client_manager.toggle_afk(client)

--- a/server/constants.py
+++ b/server/constants.py
@@ -19,7 +19,7 @@ from enum import Enum
 
 
 class TargetType(Enum):
-    # possible keys: ip, OOC, id, cname, ipid, hdid
+    # possible keys: ip, OOC, id, cname, ipid, hdid, afk
     IP = 0
     OOC_NAME = 1
     ID = 2
@@ -27,3 +27,4 @@ class TargetType(Enum):
     IPID = 4
     HDID = 5
     ALL = 6
+    AFK = 7

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -42,7 +42,8 @@ class AOProtocol(asyncio.Protocol):
         """Represents the data type of an argument for a network command."""
         STR = 1,
         STR_OR_EMPTY = 2,
-        INT = 3
+        INT = 3,
+        INT_OR_STR = 3
 
     def __init__(self, server):
         super().__init__()
@@ -150,7 +151,7 @@ class AOProtocol(asyncio.Protocol):
             return False
         if len(args) != len(types):
             return False
-        for i, arg in enumerate(args):
+        for i, arg in enumerate(args):          
             if len(arg) == 0 and types[i] != self.ArgType.STR_OR_EMPTY:
                 return False
             if types[i] == self.ArgType.INT:
@@ -341,15 +342,14 @@ class AOProtocol(asyncio.Protocol):
             return
 
         target_area = []
-
-        if self.validate_net_cmd(args, self.ArgType.STR,
-                                 self.ArgType.STR_OR_EMPTY, self.ArgType.STR,
-                                 self.ArgType.STR, self.ArgType.STR,
-                                 self.ArgType.STR, self.ArgType.STR,
-                                 self.ArgType.INT, self.ArgType.INT,
-                                 self.ArgType.INT, self.ArgType.INT,
-                                 self.ArgType.INT, self.ArgType.INT,
-                                 self.ArgType.INT, self.ArgType.INT):
+        if self.validate_net_cmd(args, self.ArgType.STR, # msg_type
+                                 self.ArgType.STR_OR_EMPTY, self.ArgType.STR,#pre, folder
+                                 self.ArgType.STR, self.ArgType.STR,# anim, text
+                                 self.ArgType.STR, self.ArgType.STR,#pos, sfx
+                                 self.ArgType.INT, self.ArgType.INT,#anim_type, cid
+                                 self.ArgType.INT, self.ArgType.INT_OR_STR,#sfx_delay, button
+                                 self.ArgType.INT, self.ArgType.INT,#evidence, flip
+                                 self.ArgType.INT, self.ArgType.INT):#ding, color
             # Pre-2.6 validation monstrosity.
             msg_type, pre, folder, anim, text, pos, sfx, anim_type, cid, sfx_delay, button, evidence, flip, ding, color = args
             showname = ""
@@ -357,13 +357,13 @@ class AOProtocol(asyncio.Protocol):
             offset_pair = 0
             nonint_pre = 0
         elif self.validate_net_cmd(
-                args, self.ArgType.STR, self.ArgType.STR_OR_EMPTY,
-                self.ArgType.STR, self.ArgType.STR, self.ArgType.STR,
-                self.ArgType.STR, self.ArgType.STR, self.ArgType.INT,
-                self.ArgType.INT, self.ArgType.INT, self.ArgType.INT,
-                self.ArgType.INT, self.ArgType.INT, self.ArgType.INT,
-                self.ArgType.INT, self.ArgType.STR_OR_EMPTY, self.ArgType.INT,
-                self.ArgType.INT, self.ArgType.INT):
+                args, self.ArgType.STR, self.ArgType.STR_OR_EMPTY,#msg_type, pre
+                self.ArgType.STR, self.ArgType.STR, self.ArgType.STR,#folder, anim, text
+                self.ArgType.STR, self.ArgType.STR, self.ArgType.INT,# pos, sfx, anim_type
+                self.ArgType.INT, self.ArgType.INT, self.ArgType.INT_OR_STR,#cid, sfx_delay, button
+                self.ArgType.INT, self.ArgType.INT, self.ArgType.INT,#evidence, flip, ding
+                self.ArgType.INT, self.ArgType.STR_OR_EMPTY, self.ArgType.INT, #color, showname, charid_pair
+                self.ArgType.INT, self.ArgType.INT): #offset_pair, nonint_pre
             # 2.6+ validation monstrosity.
             msg_type, pre, folder, anim, text, pos, sfx, anim_type, cid, sfx_delay, button, evidence, flip, ding, color, showname, charid_pair, offset_pair, nonint_pre = args
             if len(showname
@@ -430,8 +430,11 @@ class AOProtocol(asyncio.Protocol):
             return
         if sfx_delay < 0:
             return
-        if button not in (0, 1, 2, 3, 4):
-            return
+        if '4' in button and "<and>" not in button:
+            if not button.isdigit():
+               print("NOOOOO" + button)
+               return
+        print(button)
         if evidence < 0:
             return
         if ding not in (0, 1):

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -675,7 +675,7 @@ class AOProtocol(asyncio.Protocol):
 
                 if self.client.area.jukebox:
                     showname = ''
-                    if len(args)>3:
+                    if len(args) > 3:
                         showname = args[2]
                         if len(
                                 showname

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -110,7 +110,7 @@ class AOProtocol(asyncio.Protocol):
         self.client = self.server.new_client(transport)
         if not self.server.client_manager.new_client_preauth(transport):
             self.client.send_command('BD', 'DOS Prevention. Maximum clients reached. \n Disconnect one of your clients to continue')
-            self.client.disconnect
+            self.client.disconnect()
             return
         # Client needs to send CHECK#% within the timeout - otherwise,
         # it will be automatically dropped.

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -108,9 +108,10 @@ class AOProtocol(asyncio.Protocol):
         :param transport: the transport object
         """
         self.client = self.server.new_client(transport)
-        if not(self.server.client_manager.new_client_auth(transport)):
+        if not self.server.client_manager.new_client_preauth(transport):
             self.client.send_command('BD', 'DOS Prevention. Maximum clients reached. \n Disconnect one of your clients to continue')
             self.client.disconnect
+            return
         # Client needs to send CHECK#% within the timeout - otherwise,
         # it will be automatically dropped.
         self.ping_timeout = asyncio.get_event_loop().call_later(
@@ -435,9 +436,7 @@ class AOProtocol(asyncio.Protocol):
             return
         if '4' in button and "<and>" not in button:
             if not button.isdigit():
-               print("NOOOOO" + button)
                return
-        print(button)
         if evidence < 0:
             return
         if ding not in (0, 1):

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -137,7 +137,8 @@ class TsuServer3:
         :param transport: asyncio transport
         :returns: created client object
         """
-        c = self.client_manager.new_client(transport)
+        #if not(self.client_manager.new_client_auth(transport)):
+        c = self.client_manager.new_client(transport) #fx this
         c.server = self
         c.area = self.area_manager.default_area()
         c.area.new_client(c)
@@ -362,7 +363,7 @@ class TsuServer3:
 
     def send_arup(self, args):
         """Update the area properties for 2.6 clients.
-        
+
         Playercount:
             ARUP#0#<area1_p: int>#<area2_p: int>#...
         Status:
@@ -372,7 +373,7 @@ class TsuServer3:
         Lockedness:
             ARUP#3##<area1_l: string>##<area2_l: string>#...
 
-        :param args: 
+        :param args:
 
         """
         if len(args) < 2:

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -137,7 +137,7 @@ class TsuServer3:
         :param transport: asyncio transport
         :returns: created client object
         """
-        c = self.client_manager.new_client(transport) 
+        c = self.client_manager.new_client(transport)
         c.server = self
         c.area = self.area_manager.default_area()
         c.area.new_client(c)

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -137,8 +137,7 @@ class TsuServer3:
         :param transport: asyncio transport
         :returns: created client object
         """
-        #if not(self.client_manager.new_client_auth(transport)):
-        c = self.client_manager.new_client(transport) #fx this
+        c = self.client_manager.new_client(transport) 
         c.server = self
         c.area = self.area_manager.default_area()
         c.area.new_client(c)
@@ -182,6 +181,8 @@ class TsuServer3:
 
         if isinstance(self.config['modpass'], str):
             self.config['modpass'] = {'default': {'password': self.config['modpass']}}
+        if 'multiclient_limit' not in self.config:
+            self.config['multiclient_limit'] = 16
 
     def load_characters(self):
         """Load the character list from a YAML file."""


### PR DESCRIPTION
Right, so this PR adds:
**Multi Connection Cap**
Essenstially multi client cap. If the connections made by the same ipid exceed the limit, the server will send a bd packet and refuse any conversations. I know this is a bit aggressive but it should extinguish the DOS issues.

**AFK system**
You can do /afk, it will give you an afk tag. It is removed whenever you speak IC or when you do /afk again.
Also, cms now have the option to do /area_kick afk .