### PR TITLE
Send back ~stop.mp3 if the song that's played is a category

### DIFF
--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -753,8 +753,8 @@ class AOProtocol(asyncio.Protocol):
                 )
                 return
             try:
-                if args[0] == "~stop.mp3":
-                    name, length = args[0], 0
+                if args[0] == "~stop.mp3" or self.server.get_song_is_category(self.server.music_list, args[0]):
+                    name, length = "~stop.mp3", 0
                 else:
                     name, length = self.server.get_song_data(
                         self.server.music_list, args[0])

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -351,6 +351,20 @@ class TsuServer3:
                         return song['name'], -1
         raise ServerError('Music not found.')
 
+    def get_song_is_category(self, music_list, music):
+        """
+        Get whether a track is a category.
+        :param music_list: music list to search
+        :param music: track name
+        :returns: bool
+        """
+        for item in music_list:
+            if 'category' not in item: #skip settings n stuff
+                continue
+            if item['category'] == music:
+                return True
+        return False
+    
     def send_all_cmd_pred(self, cmd, *args, pred=lambda x: True):
         """
         Broadcast an AO-compatible command to all clients that satisfy


### PR DESCRIPTION
Should help the transition from 2.8-style "play a category to stop the music" to 2.9-style UI-based song stoppage.