### PR TITLE
If the area is spectatable, don't let spectators change the background.

### DIFF
--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -32,7 +32,9 @@ def ooc_cmd_bg(client, arg):
     if len(arg) == 0:
         raise ArgumentError('You must specify a name. Use /bg <background>.')
     if not client.is_mod and client.area.bg_lock == "true":
-        raise AreaError("This area's background is locked")
+        raise AreaError("This area's background is locked!")
+    elif not client.area.can_send_message(client):
+        raise AreaError("You are not permitted to change the background in this area!")
     try:
         client.area.change_background(arg)
     except AreaError:


### PR DESCRIPTION
Corrects an unfortunate oversight that was allowing bad actors on Official Unofficial to harass cases by rapidly changing the background during the case.