### PR TITLE
kick people out if they don't follow protocol

### DIFF
--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -206,6 +206,10 @@ class AOProtocol(asyncio.Protocol):
         :param args: a list containing all the arguments
 
         """
+        if self.client.hdid != '':
+            self.client.disconnect()
+            return
+
         if not self.validate_net_cmd(args, self.ArgType.STR, needs_auth=False):
             return
         hdid = self.client.hdid = args[0]

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -206,7 +206,7 @@ class AOProtocol(asyncio.Protocol):
         :param args: a list containing all the arguments
 
         """
-        if self.client.hdid != '':
+        if self.client.is_checked:
             self.client.disconnect()
             return
 


### PR DESCRIPTION
unsure if we should use an empty hdid or client.is_checked
i think an empty hdid should not be valid