### PR TITLE
Sc send with escape chars

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -32,7 +32,6 @@ class ClientManager:
 
         Clients may only belong to a single room.
         """
-
         def __init__(self, server, transport, user_id, ipid):
             self.is_checked = False
             self.transport = transport
@@ -159,7 +158,7 @@ class ClientManager:
             name_ws = name.replace(' ', '')
             if not name_ws or name_ws.isdigit():
                 return False
-            if not set(name_ws).issubset(printset):  # illegal chars in ooc name
+            if not set(name_ws).issubset(printset): #illegal chars in ooc name
                 return False
             for client in self.server.client_manager.clients:
                 if client.name == name:
@@ -203,7 +202,7 @@ class ClientManager:
 
             new_char = self.char_name
             database.log_room('char.change', self, self.area,
-                              message={'from': old_char, 'to': new_char})
+                message={'from': old_char, 'to': new_char})
 
         def change_music_cd(self):
             """
@@ -295,6 +294,7 @@ class ClientManager:
             # KEEP THE ASTERISK
             self.send_command('FA', *area_list)
 
+
         def change_area(self, area):
             """
             Switch the client to another area, unless the area is locked.
@@ -333,8 +333,7 @@ class ClientManager:
                 f'Changed area to {area.name} [{self.area.status}].')
             self.area.send_command('CharsCheck',
                                    *self.get_available_char_list())
-            self.area.send_command(
-                'CharsCheck', *self.get_available_char_list())
+            self.area.send_command('CharsCheck', *self.get_available_char_list())
             self.send_command('HP', 1, self.area.hp_def)
             self.send_command('HP', 2, self.area.hp_pro)
             self.send_command('BN', self.area.background, self.pos)
@@ -432,7 +431,7 @@ class ClientManager:
                         client_list = client_list.clients
                     area_info = self.get_area_info(i, mods, afk_check)
                     if len(client_list) > 0 or len(
-                            self.server.area_manager.areas[i].owners) > 0:
+                               self.server.area_manager.areas[i].owners) > 0:
                         cnt += len(client_list)
                         info += f'{area_info}'
                 if afk_check:
@@ -509,7 +508,7 @@ class ClientManager:
             modpasses = self.server.config['modpass']
             if isinstance(modpasses, dict):
                 matches = [k for k in modpasses
-                           if modpasses[k]['password'] == password]
+                    if modpasses[k]['password'] == password]
             elif modpasses == password:
                 matches = ['default']
             else:
@@ -543,7 +542,7 @@ class ClientManager:
             """
             self.pos = pos
             self.send_ooc(f'Position set to {pos}.')
-            self.send_command('SP', self.pos)  # Send a "Set Position" packet
+            self.send_command('SP', self.pos) #Send a "Set Position" packet
             self.send_command('LE', *self.area.get_evidence_list(self))
 
         def set_mod_call_delay(self):
@@ -599,7 +598,7 @@ class ClientManager:
             raise ClientError
 
         peername = transport.get_extra_info('peername')[0]
-
+        
         c = self.Client(
             self.server, transport, user_id,
             database.ipid(peername))
@@ -643,7 +642,6 @@ class ClientManager:
         :param local: search in current area only (Default value = False)
         :param single: search only a single user (Default value = False)
         """
-        print(client, key, value)
         areas = None
         if local:
             areas = [client.area]
@@ -655,7 +653,6 @@ class ClientManager:
                 targets += self.get_targets(client, nkey, value, local)
         for area in areas:
             for client in area.clients:
-                print(vars(client))
                 if key == TargetType.IP:
                     if value.lower().startswith(client.ip.lower()):
                         targets.append(client)
@@ -668,7 +665,7 @@ class ClientManager:
                             client.char_name.lower()):
                         targets.append(client)
                 elif key == TargetType.ID:
-                    if client.char_id == value:
+                    if client.id == value:
                         targets.append(client)
                 elif key == TargetType.IPID:
                     if client.ipid == value:
@@ -695,14 +692,11 @@ class ClientManager:
         return clients
 
     def toggle_afk(self, client):
-        if client in client.area.afkers:
-            client.area.broadcast_ooc(
-                '{} is no longer AFK.'.format(client.char_name))
-            # Making the server a bit friendly wouldn't hurt, right?
-            client.send_ooc('You are no longer AFK. Welcome back!')
-            client.area.afkers.remove(client)
-        else:
-            client.area.broadcast_ooc(
-                '{} is now AFK.'.format(client.char_name))
-            client.send_ooc('You are now AFK. Have a good day!')
-            client.area.afkers.append(client)
+            if client in client.area.afkers:
+                client.area.broadcast_ooc('{} is no longer AFK.'.format(client.char_name))
+                client.send_ooc('You are no longer AFK. Welcome back!')  # Making the server a bit friendly wouldn't hurt, right?
+                client.area.afkers.remove(client)
+            else:
+                client.area.broadcast_ooc('{} is now AFK.'.format(client.char_name))
+                client.send_ooc('You are now AFK. Have a good day!')
+                client.area.afkers.append(client)

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -32,6 +32,7 @@ class ClientManager:
 
         Clients may only belong to a single room.
         """
+
         def __init__(self, server, transport, user_id, ipid):
             self.is_checked = False
             self.transport = transport
@@ -158,7 +159,7 @@ class ClientManager:
             name_ws = name.replace(' ', '')
             if not name_ws or name_ws.isdigit():
                 return False
-            if not set(name_ws).issubset(printset): #illegal chars in ooc name
+            if not set(name_ws).issubset(printset):  # illegal chars in ooc name
                 return False
             for client in self.server.client_manager.clients:
                 if client.name == name:
@@ -202,7 +203,7 @@ class ClientManager:
 
             new_char = self.char_name
             database.log_room('char.change', self, self.area,
-                message={'from': old_char, 'to': new_char})
+                              message={'from': old_char, 'to': new_char})
 
         def change_music_cd(self):
             """
@@ -294,7 +295,6 @@ class ClientManager:
             # KEEP THE ASTERISK
             self.send_command('FA', *area_list)
 
-
         def change_area(self, area):
             """
             Switch the client to another area, unless the area is locked.
@@ -333,7 +333,8 @@ class ClientManager:
                 f'Changed area to {area.name} [{self.area.status}].')
             self.area.send_command('CharsCheck',
                                    *self.get_available_char_list())
-            self.area.send_command('CharsCheck', *self.get_available_char_list())
+            self.area.send_command(
+                'CharsCheck', *self.get_available_char_list())
             self.send_command('HP', 1, self.area.hp_def)
             self.send_command('HP', 2, self.area.hp_pro)
             self.send_command('BN', self.area.background, self.pos)
@@ -431,7 +432,7 @@ class ClientManager:
                         client_list = client_list.clients
                     area_info = self.get_area_info(i, mods, afk_check)
                     if len(client_list) > 0 or len(
-                               self.server.area_manager.areas[i].owners) > 0:
+                            self.server.area_manager.areas[i].owners) > 0:
                         cnt += len(client_list)
                         info += f'{area_info}'
                 if afk_check:
@@ -508,7 +509,7 @@ class ClientManager:
             modpasses = self.server.config['modpass']
             if isinstance(modpasses, dict):
                 matches = [k for k in modpasses
-                    if modpasses[k]['password'] == password]
+                           if modpasses[k]['password'] == password]
             elif modpasses == password:
                 matches = ['default']
             else:
@@ -542,7 +543,7 @@ class ClientManager:
             """
             self.pos = pos
             self.send_ooc(f'Position set to {pos}.')
-            self.send_command('SP', self.pos) #Send a "Set Position" packet
+            self.send_command('SP', self.pos)  # Send a "Set Position" packet
             self.send_command('LE', *self.area.get_evidence_list(self))
 
         def set_mod_call_delay(self):
@@ -598,7 +599,7 @@ class ClientManager:
             raise ClientError
 
         peername = transport.get_extra_info('peername')[0]
-        
+
         c = self.Client(
             self.server, transport, user_id,
             database.ipid(peername))
@@ -642,6 +643,7 @@ class ClientManager:
         :param local: search in current area only (Default value = False)
         :param single: search only a single user (Default value = False)
         """
+        print(client, key, value)
         areas = None
         if local:
             areas = [client.area]
@@ -653,6 +655,7 @@ class ClientManager:
                 targets += self.get_targets(client, nkey, value, local)
         for area in areas:
             for client in area.clients:
+                print(vars(client))
                 if key == TargetType.IP:
                     if value.lower().startswith(client.ip.lower()):
                         targets.append(client)
@@ -665,7 +668,7 @@ class ClientManager:
                             client.char_name.lower()):
                         targets.append(client)
                 elif key == TargetType.ID:
-                    if client.id == value:
+                    if client.char_id == value:
                         targets.append(client)
                 elif key == TargetType.IPID:
                     if client.ipid == value:
@@ -692,11 +695,14 @@ class ClientManager:
         return clients
 
     def toggle_afk(self, client):
-            if client in client.area.afkers:
-                client.area.broadcast_ooc('{} is no longer AFK.'.format(client.char_name))
-                client.send_ooc('You are no longer AFK. Welcome back!')  # Making the server a bit friendly wouldn't hurt, right?
-                client.area.afkers.remove(client)
-            else:
-                client.area.broadcast_ooc('{} is now AFK.'.format(client.char_name))
-                client.send_ooc('You are now AFK. Have a good day!')
-                client.area.afkers.append(client)
+        if client in client.area.afkers:
+            client.area.broadcast_ooc(
+                '{} is no longer AFK.'.format(client.char_name))
+            # Making the server a bit friendly wouldn't hurt, right?
+            client.send_ooc('You are no longer AFK. Welcome back!')
+            client.area.afkers.remove(client)
+        else:
+            client.area.broadcast_ooc(
+                '{} is now AFK.'.format(client.char_name))
+            client.send_ooc('You are now AFK. Have a good day!')
+            client.area.afkers.append(client)

--- a/server/constants.py
+++ b/server/constants.py
@@ -30,7 +30,16 @@ class TargetType(Enum):
     ALL = 6
     AFK = 7
 
+
 class MusicEffect(IntFlag):
     FADE_IN = 1
     FADE_OUT = 2
     SYNC_POS = 4
+
+
+ESCAPE_CHARACTERS = {
+    '%': '<percent>',
+    '#': '<num>',
+    '$': '<dollar>',
+    '&': '<and>'
+}

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -331,9 +331,13 @@ class AOProtocol(asyncio.Protocol):
         AC#%
 
         """
-        escaped_char_list = self._change_to_escape_characters(
-            self.server.char_list)
-        self.client.send_command('SC', *escaped_char_list)
+        for i, char in enumerate(self.server.char_list):
+            for esc in ESCAPE_CHARACTERS.keys():
+                if esc in char:
+                    char = char.replace(esc, ESCAPE_CHARACTERS[esc])
+            self.server.char_list[i] = char
+            
+        self.client.send_command('SC', *self.server.char_list)
 
     def net_cmd_rm(self, _):
         """Asks for the whole music list (AO2)

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -336,7 +336,7 @@ class AOProtocol(asyncio.Protocol):
                 if esc in char:
                     char = char.replace(esc, ESCAPE_CHARACTERS[esc])
             self.server.char_list[i] = char
-            
+
         self.client.send_command('SC', *self.server.char_list)
 
     def net_cmd_rm(self, _):
@@ -1127,29 +1127,6 @@ class AOProtocol(asyncio.Protocol):
 
         """
         self.net_cmd_ct(['opban', '/ban {}'.format(args[0])])
-
-    @classmethod
-    def _change_to_escape_characters(cls, list_to_change: List[str]) -> List[str]:
-        escaped_names = []
-        for not_escaped_string in list_to_change:
-            if cls._contains_escape_character(not_escaped_string):
-                escaped_name = cls._add_escape_characters(not_escaped_string)
-            else:
-                escaped_name = not_escaped_string
-            escaped_names.append(escaped_name)
-        return escaped_names
-
-    @staticmethod
-    def _contains_escape_character(word: str) -> bool:
-        return any(char for char in ESCAPE_CHARACTERS.keys() if char in word)
-
-    @staticmethod
-    def _add_escape_characters(word_to_change: str) -> str:
-        for char in word_to_change:
-            escape_character = ESCAPE_CHARACTERS.get(char)
-            if escape_character:
-                word_to_change = word_to_change.replace(char, escape_character)
-        return word_to_change
 
     net_cmd_dispatcher = {
         'HI': net_cmd_hi,  # handshake


### PR DESCRIPTION
This PR is to fix issue #124 

I tried to keep the readability of the functions pretty plainly so we don't have to add documentation for every function since it's easy (in my opinion) to let documentation get stale quick. Kept the type hinting. 

The decision for me to add the escape characters just before the SC packet is send and not when `char_list` is made is that another process relies on the un-escaped version of `char_list`. I've attached an image that shows the updated functionality. It's important to remember that although this fixes the issue, [there is a different issue with the client ](https://github.com/AttorneyOnline/AO2-Client/issues/430)that makes characters with escape characters in their name not appear properly

![image](https://user-images.githubusercontent.com/36182383/105616665-aa6a9c80-5da6-11eb-99fe-3a1cf486a121.png)


