### PR TITLE
Prevent index error

### DIFF
--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -638,10 +638,9 @@ class AOProtocol(asyncio.Protocol):
         if evidence not in self.client.evi_list:
             evidence = 0
         # Reveal evidence to everyone if hidden
-        elif evidence:
-            if self.client.area.evi_list.evidences[self.client.evi_list[evidence] - 1].pos != 'all':
-                self.client.area.evi_list.evidences[self.client.evi_list[evidence] - 1].pos = 'all'
-                self.client.area.broadcast_evidence_list()
+        elif evidence and self.client.area.evi_list.evidences[self.client.evi_list[evidence] - 1].pos != 'all':
+            self.client.area.evi_list.evidences[self.client.evi_list[evidence] - 1].pos = 'all'
+            self.client.area.broadcast_evidence_list()
 
 
         # Here, we check the pair stuff, and save info about it to the client.

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -635,13 +635,14 @@ class AOProtocol(asyncio.Protocol):
                 "Your message is a repeat of the last one. Don't spam!")
             return
 
+        if evidence not in self.client.evi_list:
+            evidence = 0
         # Reveal evidence to everyone if hidden
-        if evidence:
-            if self.client.area.evi_list.evidences[
-                    self.client.evi_list[evidence] - 1].pos != 'all':
-                self.client.area.evi_list.evidences[
-                    self.client.evi_list[evidence] - 1].pos = 'all'
+        elif evidence:
+            if self.client.area.evi_list.evidences[self.client.evi_list[evidence] - 1].pos != 'all':
+                self.client.area.evi_list.evidences[self.client.evi_list[evidence] - 1].pos = 'all'
                 self.client.area.broadcast_evidence_list()
+
 
         # Here, we check the pair stuff, and save info about it to the client.
         # Notably, while we only get a charid_pair and an offset, we send back a chair_pair, an emote, a talker offset


### PR DESCRIPTION
Fixes #101 

The issue was that the evidence number didn't exist within the clients evidence list. By checking to see if the evidence exists in the client list, we can prevent it from throwing an index error if someone deletes the evidence on their end. 

We set it to 0 because the evidence list for a client, when empty, contains the number 0. `[0]`

Short and sweet!