### PR TITLE
Send only horizontal offset to pre-2.9 clients

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -39,6 +39,7 @@ class ClientManager:
             self.is_checked = False
             self.transport = transport
             self.hdid = ''
+            self.version = ''
             self.id = user_id
             self.char_id = -1
             self.area = server.area_manager.default_area()
@@ -128,6 +129,19 @@ class ClientManager:
                             lst[11] = evi_num
                             args = tuple(lst)
                             break
+                    # <2.9 can't parse Y offset so we strip it out based on version
+                    c_version = self.version.split('.')
+                    if len(c_version) > 1:
+                        if c_version[0] == '2' and int(c_version[1]) <= 8:
+                            lst = list(args)
+                            offset_pair_list = lst[19].split('<and>')
+                            print(offset_pair_list)
+                            lst[19] = offset_pair_list[0]
+                            other_offset_list = lst[20].split('<and>')
+                            print(other_offset_list)
+                            lst[20] = other_offset_list[0]
+                            args = tuple(lst)
+                            
                 self.send_raw_message(
                     f'{command}#{"#".join([str(x) for x in args])}#%')
             else:

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -34,18 +34,14 @@ class ClientManager:
 
         Clients may only belong to a single room.
         """
-
-        class ClientVersion:
-            def __init__ (self, major: str, minor: str, patch: str):
-                self.major = major
-                self.minor = minor
-                self.patch = patch
         
         def __init__(self, server, transport: asyncio.Transport, user_id: int, ipid: int):
             self.is_checked = False
             self.transport = transport
             self.hdid = ''
-            self.version = self.ClientVersion("", "", "")
+            self.release = ''
+            self.major_version = ''
+            self.minor_version = ''
             self.id = user_id
             self.char_id = -1
             self.area = server.area_manager.default_area()

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -119,25 +119,25 @@ class ClientManager:
 
             Args:
                 command (str): command name
-                *args: list of arguments
+                *args: tuple containing the MS packet
             """
             if args:
                 if command == 'MS':
                     for evi_num in range(len(self.evi_list)):
                         if self.evi_list[evi_num] == args[11]:
-                            lst = list(args)
+                            lst = list(args) # convert to a list so we can modify it
                             lst[11] = evi_num
-                            args = tuple(lst)
+                            args = tuple(lst) # then convert back to a tuple when finished
                             break
                     # <2.9 can't parse Y offset so we strip it out based on version
-                    c_version = self.version.split('.')
-                    if len(c_version) > 1:
+                    c_version = self.version.split('.') # i.e. ['2','9','0'] or ['2','8','5']
+                    if len(c_version) > 1: # sanity check, version strings /should/ be in x.x.x format 
                         try:
                             if c_version[0] == '2' and int(c_version[1]) <= 8:
-                                lst = list(args)
-                                offset_pair_list = lst[19].split('<and>')
+                                lst = list(args) 
+                                offset_pair_list = lst[19].split('<and>') # MS arg 19 is self offset
                                 lst[19] = offset_pair_list[0]
-                                other_offset_list = lst[20].split('<and>')
+                                other_offset_list = lst[20].split('<and>') # MS arg 20 is paired offset
                                 lst[20] = other_offset_list[0]
                                 args = tuple(lst)
                         except ValueError: # we can't figure out this version number, just send both offsets

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -132,7 +132,7 @@ class ClientManager:
                             args = tuple(lst) # then convert back to a tuple when finished
                             break
                         # <2.9 can't parse Y offset so we strip it out based on version
-                        if self.version.major == '2' and self.version.minor in ['8', '7', '6']:
+                        if self.release == '2' and self.major_version in ['8', '7', '6']:
                             lst = list(args) 
                             offset_pair_list = lst[19].split('<and>') # MS arg 19 is self offset
                             lst[19] = offset_pair_list[0]

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -132,13 +132,16 @@ class ClientManager:
                     # <2.9 can't parse Y offset so we strip it out based on version
                     c_version = self.version.split('.')
                     if len(c_version) > 1:
-                        if c_version[0] == '2' and int(c_version[1]) <= 8:
-                            lst = list(args)
-                            offset_pair_list = lst[19].split('<and>')
-                            lst[19] = offset_pair_list[0]
-                            other_offset_list = lst[20].split('<and>')
-                            lst[20] = other_offset_list[0]
-                            args = tuple(lst)
+                        try:
+                            if c_version[0] == '2' and int(c_version[1]) <= 8:
+                                lst = list(args)
+                                offset_pair_list = lst[19].split('<and>')
+                                lst[19] = offset_pair_list[0]
+                                other_offset_list = lst[20].split('<and>')
+                                lst[20] = other_offset_list[0]
+                                args = tuple(lst)
+                        except ValueError: # we can't figure out this version number, just send both offsets
+                            pass
                             
                 self.send_raw_message(
                     f'{command}#{"#".join([str(x) for x in args])}#%')

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -135,10 +135,8 @@ class ClientManager:
                         if c_version[0] == '2' and int(c_version[1]) <= 8:
                             lst = list(args)
                             offset_pair_list = lst[19].split('<and>')
-                            print(offset_pair_list)
                             lst[19] = offset_pair_list[0]
                             other_offset_list = lst[20].split('<and>')
-                            print(other_offset_list)
                             lst[20] = other_offset_list[0]
                             args = tuple(lst)
                             

--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -119,7 +119,7 @@ class ClientManager:
 
             Args:
                 command (str): command name
-                *args: tuple containing the MS packet
+                *args: tuple containing the packet arguments
             """
             if args:
                 if command == 'MS':

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -251,6 +251,7 @@ class AOProtocol(asyncio.Protocol):
 
         ID#<pv:int>#<software:string>#<version:string>#%
         """
+        self.client.version = args[1]
         self.client.send_command('FL', 'yellowtext', 'customobjections',
                                  'flipping', 'fastloading', 'noencryption',
                                  'deskmod', 'evidence', 'modcall_reason',

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -251,7 +251,16 @@ class AOProtocol(asyncio.Protocol):
 
         ID#<pv:int>#<software:string>#<version:string>#%
         """
-        self.client.version = args[1]
+        version = args[1].split(".")
+        if len(version) <= 1:
+            self.client.version.major = args[1]
+        elif len(version) >= 2:
+            self.client.version.major = version[0]
+            self.client.version.minor = version[1]
+        if len(version) >= 3:
+            self.client.version.patch = version[2]
+            
+        
         self.client.send_command('FL', 'yellowtext', 'customobjections',
                                  'flipping', 'fastloading', 'noencryption',
                                  'deskmod', 'evidence', 'modcall_reason',

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -253,12 +253,12 @@ class AOProtocol(asyncio.Protocol):
         """
         version = args[1].split(".")
         if len(version) <= 1:
-            self.client.version.major = args[1]
+            self.client.release = args[1]
         elif len(version) >= 2:
-            self.client.version.major = version[0]
-            self.client.version.minor = version[1]
+            self.client.release = version[0]
+            self.client.major_version = version[1]
         if len(version) >= 3:
-            self.client.version.patch = version[2]
+            self.client.minor_version = version[2]
             
         
         self.client.send_command('FL', 'yellowtext', 'customobjections',


### PR DESCRIPTION
This is hacky, but it allows for complete backwards compatibility. Which is important, I guess.