### PR TITLE
Testimony recording system fixes and additions

### DIFF
--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -597,7 +597,7 @@ class AreaManager:
                 Returns:
                     bool: whether the statement was amended
                 """
-                if index < 1 or index > len(self.statements) + 1:
+                if index < 1 or index >= len(self.statements): #changed maximum value of index, otherwise it'd allow you to 'amend' testimony indexes which don't exist, to no avail - tested
                     return False
                 message[14] = 1 # message[14] is color, and 1 is (by default) green
                 message = tuple(message)
@@ -607,6 +607,31 @@ class AreaManager:
                         self.statements[i] = message
                         return True
                     i += 1
+                return True
+
+            def insert_statement(self, index: int, message: list) -> bool:
+                """Insert a statement into the testimony.
+                Args:
+                    index (int): index of the statement to insert the new one AFTER
+                    message (list): the new statement
+                Returns:
+                    bool: whether the statement was inserted
+                """
+                if index < 0 or index >= len(self.statements): #having the index of 0 available makes it possible to insert a statement before the first one, right after title
+                    return False
+                message[14] = 1 # message[14] is color, and 1 is (by default) green
+                message = tuple(message)
+                i = 0
+                tempsti = [''] * (len(self.statements) + 1);
+                while i < index + 1:
+                    tempsti[i] = self.statements[i]
+                    i += 1
+                tempsti[index + 1] = message
+                i += 1
+                while i < len(tempsti):
+                    tempsti[i] = self.statements[i-1]
+                    i += 1
+                self.statements = tempsti
                 return True
             
         def start_testimony(self, client: ClientManager.Client, title: str) -> bool:
@@ -703,6 +728,26 @@ class AreaManager:
                 return True
             else:
                 client.send_ooc('Couldn\'t amend statement ' + str(index) + '. Are you sure it exists?')
+                return False
+
+        def insert_testimony(self, client: ClientManager.Client, index:int, statement: list) -> bool:
+            """
+            Insert into the testimony a new <statement> after the statement at <index>.
+            Args:
+                client (ClientManager.Client): requester
+                index (int): index of the statement to insert AFTER
+                statement (list): the affected statement
+            Returns:
+                bool: whether the insert was successful
+            """
+            if client not in self.owners and (self.evidence_mod == "HiddenCM" or self.evidence_mod == "Mods"):
+                client.send_ooc('You don\'t have permission to amend testimony in this area!')
+                return False
+            if self.testimony.insert_statement(index, statement):
+                client.send_ooc('Inserted a new statement after statement ' + str(index) + ' successfully.')
+                return True
+            else:
+                client.send_ooc('Couldn\'t find statement ' + str(index) + '. Are you sure it exists?')
                 return False
             
         def remove_statement(self, client: ClientManager.Client, index: int) -> bool:

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -621,17 +621,7 @@ class AreaManager:
                     return False
                 message[14] = 1 # message[14] is color, and 1 is (by default) green
                 message = tuple(message)
-                i = 0
-                tempsti = [''] * (len(self.statements) + 1);
-                while i < index + 1:
-                    tempsti[i] = self.statements[i]
-                    i += 1
-                tempsti[index + 1] = message
-                i += 1
-                while i < len(tempsti):
-                    tempsti[i] = self.statements[i-1]
-                    i += 1
-                self.statements = tempsti
+                self.statements.insert(index + 1, message)
                 return True
             
         def start_testimony(self, client: ClientManager.Client, title: str) -> bool:

--- a/server/commands/casing.py
+++ b/server/commands/casing.py
@@ -19,6 +19,7 @@ __all__ = [
     'ooc_cmd_unblockwtce',
     'ooc_cmd_judgelog',
     'ooc_cmd_testimony',
+    'ooc_cmd_cleartesti',
     'ooc_cmd_afk'
 ]
 
@@ -329,4 +330,23 @@ def ooc_cmd_testimony(client, arg):
             testi_msg += x[4]
             i = i + 1
         client.send_ooc(testi_msg)
+
+@mod_only(area_owners=True)
+def ooc_cmd_cleartesti(client, arg):
+    """
+    Clears the testimony list, deleting all statements.
+    Very handy, since otherwise you'd have to rewrite the testimony with
+    a 1-statement new one and remove that statement manually.
+    For mods and CM use only to prevent abuse.
+    Usage: /cleartesti
+    """
+    if len(arg) != 0:
+        raise ArgumentError('This command does not take any arguments.')
+    testi = list(client.area.testimony.statements)
+    if len(testi) <= 1:
+        raise ServerError('There is no testimony in this area.')
+    else:
+        client.area.testimony.statements = []
+        client.area.testimony.title = ''
+        client.send_ooc('You have cleared the testimony.')
         

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -561,6 +561,23 @@ class AOProtocol(asyncio.Protocol):
                     self.client.send_ooc(
                         "That does not look like a valid statement number!")
                     return
+            elif text.startswith('/insert '):
+                part = text.split(' ')
+                text = ' '.join(part[2:])
+                args[4] = text
+                color = 1
+                try:
+                    index = int(part[1])
+                    if not self.client.area.insert_testimony(self.client, index, args):
+                        return
+                    if self.client.area.is_testifying:
+                        return # don't send it again or it'll be rerecorded
+                    elif self.client.area.is_examining:
+                        self.client.area.examine_index = index + 1 # jump to the amended statement
+                except ValueError:
+                    self.client.send_ooc(
+                        "That does not look like a valid statement number!")
+                    return
             elif text.startswith('/add ') and self.client.area.is_examining:
                 part = text.split(' ')
                 text = ' '.join(part[1:])


### PR DESCRIPTION
Added a few things to the testimony recording system. A handy quality-of-life OOC command for immediately clearing the testimony list for the area as well as a minor fix for amend_statement function and a new insert_statement one which allows players to insert a statement anywhere inside their testimony in the true spirit of "amending" it the way it was done in the games.