### PR TITLE
Define asset url if it does not exist

### DIFF
--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -267,6 +267,7 @@ class AOProtocol(asyncio.Protocol):
                                  'cccc_ic_support', 'arup', 'casing_alerts',
                                  'prezoom', 'looping_sfx', 'additive', 'effects',
                                  'y_offset', 'expanded_desk_mods', 'auth_packet')
+                                 
         # Send Asset packet if asset_url is defined
         if self.server.config['asset_url'] != '':
             self.client.send_command('ASS', self.server.config['asset_url'])

--- a/server/network/aoprotocol.py
+++ b/server/network/aoprotocol.py
@@ -267,9 +267,9 @@ class AOProtocol(asyncio.Protocol):
                                  'cccc_ic_support', 'arup', 'casing_alerts',
                                  'prezoom', 'looping_sfx', 'additive', 'effects',
                                  'y_offset', 'expanded_desk_mods', 'auth_packet')
-                                 
+
         # Send Asset packet if asset_url is defined
-        if self.server.config['asset_url'] != '':
+        if self.server.config['asset_url'] != None:
             self.client.send_command('ASS', self.server.config['asset_url'])
 
     def net_cmd_ch(self, _):

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -234,7 +234,7 @@ class TsuServer3:
         if 'default_ban_duration' not in self.config:
             self.config['default_ban_duration'] = 6
         if 'asset_url' not in self.config:
-            self.config['asset_url'] = ''
+            self.config['asset_url'] = None
 
     def load_characters(self):
         """Load the character list from a YAML file."""

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -233,6 +233,8 @@ class TsuServer3:
             self.config['testimony_limit'] = 30
         if 'default_ban_duration' not in self.config:
             self.config['default_ban_duration'] = 6
+        if 'asset_url' not in self.config:
+            self.config['asset_url'] = ''
 
     def load_characters(self):
         """Load the character list from a YAML file."""


### PR DESCRIPTION
~~When the yaml is parsed from the config, if the variable is not defined it will come out as an empty string. I want to keep the behavior of the empty string rather than setting it as `None` and having to check it in other place.~~

EDIT: 
I was wrong, if the value is empty in the yaml pyyaml sets it to None. This change was reflected in the latest commit