### PR TITLE
make /mods only usable by mods

### DIFF
--- a/server/commands/admin.py
+++ b/server/commands/admin.py
@@ -345,15 +345,6 @@ def ooc_cmd_online(client, _):
     """
     client.send_player_count()
 
-
-def ooc_cmd_mods(client, arg):
-    """
-    Show a list of moderators online.
-    Usage: /mods
-    """
-    client.send_area_info(-1, True)
-
-
 def ooc_cmd_unmod(client, arg):
     """
     Log out as a moderator.
@@ -366,6 +357,13 @@ def ooc_cmd_unmod(client, arg):
     client.send_ooc('you\'re not a mod now')
     client.send_command('AUTH', '-1')
 
+@mod_only()
+def ooc_cmd_mods(client, arg):
+    """
+    Show a list of moderators online.
+    Usage: /mods
+    """
+    client.send_area_info(-1, True)
 
 @mod_only()
 def ooc_cmd_ooc_mute(client, arg):


### PR DESCRIPTION
the NH metagame consists of keeping tabs on the moderators

ordinary users should not be able to tell how well or not so well staffed the mod team is