### PR TITLE
Switch to HTTP API for advertising on server list

### DIFF
--- a/config_sample/config.yaml
+++ b/config_sample/config.yaml
@@ -45,13 +45,11 @@ asset_url:
 
 # Whether or not the server should be advertised on the server list.
 use_masterserver: true
-# Don't change these unless the master server is no more
-masterserver_ip: master.aceattorneyonline.com
-masterserver_port: 27016
-
 # How the server should be listed on the server list.
 masterserver_name: My First Server
 masterserver_description: This is my flashy new server
+# Custom IP address/hostname to use on the server list
+# masterserver_custom_hostname: ao.example.com
 
 # Timeout for dead connections (in seconds).
 # To prevent issues, this value should be greater than 60.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ websockets
 arrow
 timeparse-plus
 geoip2
+pystun3

--- a/server/network/masterserverclient.py
+++ b/server/network/masterserverclient.py
@@ -16,85 +16,66 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
+import aiohttp
+import stun
 import time
+from threading import Thread
 
 import logging
 logger = logging.getLogger('debug')
 
+stun_servers = [
+    ('stun.l.google.com', 19302),
+    ('global.stun.twilio.com', 3478),
+    ('stun.voip.blackberry.com', 3478),
+]
 
+API_BASE_URL = 'https://servers.aceattorneyonline.com'
 
 class MasterServerClient:
     """Advertises information about this server to the master server."""
     def __init__(self, server):
         self.server = server
-        self.reader = None
-        self.writer = None
 
     async def connect(self):
+        async with aiohttp.ClientSession() as http:
+            while True:
+                try:
+                    await self.send_server_info(http)
+                except aiohttp.ClientError:
+                    logger.exception('Connection error occurred.')
+                finally:
+                    await asyncio.sleep(60)
+
+    def get_my_ip(self):
+        for stun_ip, stun_port in stun_servers:
+            nat_type, external_ip, _external_port = \
+                stun.get_ip_info(stun_host=stun_ip, stun_port=stun_port)
+            if nat_type == stun.Blocked:
+                continue
+            return external_ip
+
+    async def send_server_info(self, http: aiohttp.ClientSession):
         loop = asyncio.get_event_loop()
-        while True:
-            try:
-                self.reader, self.writer = await asyncio.open_connection(
-                    self.server.config['masterserver_ip'],
-                    self.server.config['masterserver_port'],
-                    loop=loop)
-                await self.handle_connection()
-            except (ConnectionRefusedError, TimeoutError,
-                    ConnectionResetError, asyncio.IncompleteReadError):
-                logger.debug('Connection error occurred.')
-                self.writer = None
-                self.reader = None
-            finally:
-                logger.debug('Retrying MS connection in 30 seconds.')
-                await asyncio.sleep(30)
-
-    async def handle_connection(self):
-        logger.debug('Master server connected.')
-        print('Master server connected ({}:{})'.format(
-            self.server.config['masterserver_ip'],
-            self.server.config['masterserver_port']))
-
-        await self.send_server_info()
-        ping_timeout = False
-        last_ping = time.time() - 20
-        while True:
-            self.reader.feed_data(b'END')
-            full_data = await self.reader.readuntil(b'END')
-            full_data = full_data[:-3]
-            if len(full_data) > 0:
-                data_list = list(full_data.split(b'#%'))[:-1]
-                for data in data_list:
-                    raw_msg = data.decode()
-                    cmd, *args = raw_msg.split('#')
-                    if cmd != 'CHECK' and cmd != 'PONG':
-                        logger.debug(f'Incoming: {raw_msg}')
-                    elif cmd == 'CHECK':
-                        await self.send_raw_message('PING#%')
-                    elif cmd == 'PONG':
-                        ping_timeout = False
-                    elif cmd == 'NOSERV':
-                        logger.debug('MS does not have our server. Readvertising.')
-                        await self.send_server_info()
-            if time.time() - last_ping > 10:
-                if ping_timeout:
-                    self.writer.close()
-                    return
-                last_ping = time.time()
-                ping_timeout = True
-                await self.send_raw_message('PING#%')
-            await asyncio.sleep(1)
-
-    async def send_server_info(self):
-        logger.debug('Advertising to MS')
         cfg = self.server.config
-        port = str(cfg['port'])
-        if cfg['use_websockets']:
-            port += '&{}'.format(cfg['websocket_port'])
-        msg = 'SCC#{}#{}#{}#{}#%'.format(port, cfg['masterserver_name'],
-                                         cfg['masterserver_description'],
-                                         self.server.software)
-        await self.send_raw_message(msg)
+        body = {
+            'ip': await loop.run_in_executor(None, self.get_my_ip),
+            'port': cfg['port'],
+            'name': cfg['masterserver_name'],
+            'description': cfg['masterserver_description'],
+            'players': self.server.player_count
+        }
 
-    async def send_raw_message(self, msg):
-        self.writer.write(msg.encode())
-        await self.writer.drain()
+        if 'masterserver_custom_hostname' in cfg:
+            body['ip'] = cfg['masterserver_custom_hostname']
+        if cfg['use_websockets']:
+            body['ws_port'] = cfg['websocket_port']
+
+        async with http.post(f'{API_BASE_URL}/servers', json=body) as res:
+            err_body = await res.text()
+            try:
+                res.raise_for_status()
+            except aiohttp.ClientResponseError as err:
+                logging.error(f"Got status={err.status} advertising {body}: {err_body}")
+
+        logger.debug(f'Heartbeat to {API_BASE_URL}/servers')

--- a/server/network/masterserverclient.py
+++ b/server/network/masterserverclient.py
@@ -51,9 +51,8 @@ class MasterServerClient:
         for stun_ip, stun_port in stun_servers:
             nat_type, external_ip, _external_port = \
                 stun.get_ip_info(stun_host=stun_ip, stun_port=stun_port)
-            if nat_type == stun.Blocked:
-                continue
-            return external_ip
+            if nat_type != stun.Blocked:
+                return external_ip
 
     async def send_server_info(self, http: aiohttp.ClientSession):
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
Instead of advertising over `master.aceattorneyonline.com:27016`, tsuserver will now send a heartbeat to the API at `https://servers.aceattorneyonline.com`. The legacy MS will be bridged this week to the HTTP server list, so this will not prevent pre-2.10 clients from discovering the server.

Because some network stacks prefer IPv6 connections over IPv4, a STUN server (ubiquitous in WebRTC) is used to get the IPv4 address, which is added to the heartbeat request.

It's also possible to pass a custom hostname or IP address, if for instance your VPS requests you to use a particular "DDoS protected address" or you want to use a hostname that can be placed on favorite lists and work across IP address changes.