### PR TITLE
Fix testimony recording

### DIFF
--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -790,8 +790,15 @@ class AreaManager:
                 except ValueError:
                     client.send_ooc("That does not look like a valid statement number!")
                     return False
-            self.send_command('MS', *self.testimony.statements[self.examine_index])
-            return True
+            if self.examine_index >= len(self.testimony.statements):
+                client.send_ooc("There aren't that many statements in the testimony!")
+                return False
+            elif self.examine_index <= 0:
+                client.send_ooc("This statement doesn't exist!")
+                return False
+            else:
+                self.send_command('MS', *self.testimony.statements[self.examine_index])
+                return True
                 
         class JukeboxVote:
             """Represents a single vote cast for the jukebox."""


### PR DESCRIPTION
Okay, so testimony recording, or editing and replaying rather, is broken when it comes to pairing. That's because relevant pairing information such as the paired character's sprites, is defined AFTER we check if the text starts with /add or /amend or whatever, and /add and /amend pass "args" into the testimony, not "send_args". This results in paired sprites being recorded wrong, essentially your partner will be a missing sprite. The only solution I could think of was to define these variables BEFORE the IC commands and actually define send_args right then and there as well as a LIST, which will contain the pairing info, and which we'll pass into the testimony. Then send_args gets redefined as a tuple again, as it should, and passed into IC chat. Is there a more elegant way? Perhaps. Do I know of it? No. Does it work the way it is? Yes.